### PR TITLE
Add PyTorch MPS device support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2026-06-16
 
+
 ### Added
 
 - multiple corresponding units for given quantities in the GUI
+- support for Apple Metal Performance Shaders (MPS) devices when using the PyTorch backend
+
+
 
 ### Fixed
 

--- a/pyRadPlan/core/xp_utils/__init__.py
+++ b/pyRadPlan/core/xp_utils/__init__.py
@@ -134,15 +134,24 @@ def choose_device(xp: Optional[ArrayNamespace] = None, gpu_index: int = 0) -> Un
     xp : Optional[ArrayNamespace], optional
         The array namespace. If None, the preferred backend is used.
     gpu_index : int, optional
-        GPU device index to use when a GPU backend is selected. Default is 0.
-        Pass ``1``, ``2``, etc. for multi-GPU setups.
+        GPU device index used for CUDA backends. Ignored when the selected backend is MPS.
+        Default is 0. Pass ``1``, ``2``, etc. for multi-GPU setups.
     """
     if xp is None:
         xp = choose_array_api_namespace()
 
     if PREFER_GPU:
-        if array_api_compat.is_torch_namespace(xp) and pytorch_gpu_available():
-            return f"cuda:{gpu_index}"
+        if array_api_compat.is_torch_namespace(xp):
+            if (
+                torch is not None
+                and hasattr(torch.backends, "mps")
+                and torch.backends.mps.is_available()
+            ):
+                return "mps"
+
+            elif pytorch_gpu_available():
+                return f"cuda:{gpu_index}"
+
         if array_api_compat.is_cupy_namespace(xp) and cupy_available():
             return str(gpu_index)
 

--- a/test/core/xp_utils/test_initialization.py
+++ b/test/core/xp_utils/test_initialization.py
@@ -137,6 +137,19 @@ def test_choose_device_torch_multi_gpu():
     assert choose_device(xp, gpu_index=1) == "cuda:1"
 
 
+@pytest.mark.skipif(
+    not (HAS_TORCH and hasattr(torch.backends, "mps")),
+    reason="PyTorch MPS backend unavailable",
+)
+def test_choose_device_torch_mps(monkeypatch):
+    import array_api_compat.torch as xp
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    assert choose_device(xp) == "mps"
+
+
 @pytest.mark.skipif(not (HAS_CUPY and CUPY_CUDA_AVAILABLE), reason="CuPy GPU not available")
 def test_choose_device_cupy():
     """Test choose_device with cupy namespace."""


### PR DESCRIPTION
## Description

<!-- Provide a clear summary of the changes and the motivation behind them.
     Link the related issue(s) below. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] Hotfix for a breaking change on `main`
- [ ] New feature
- [ ] Refactor
- [ ] Interface to external software
- [ ] DevOps / CI
- [ ] Documentation
- [x] Other — please describe:

## Checklist

<!-- All items must be checked before this PR can be merged. -->

- [x] This PR targets the `develop` branch (or `main` for hotfixes and documentation only).
- [x] The pre-commit hook has been run and all files are formatted (`ruff`).
- [x] Unit tests pass locally (`pytest test`).
- [x] New or changed code is covered by tests; coverage has not dropped significantly.
- [x] `CHANGELOG.md` has been updated in the `[UNRELEASED]` section following [Keep a Changelog](https://keepachangelog.com/) conventions.

## Testing

<!-- Describe how the changes were tested. Include relevant pytest commands or test file names. -->
Added a unit test function covering the MPS device selection logic to the script test/core/xp_utils/test_initialization.py

`pytest test/core/xp_utils/test_initialization.py`


## Additional Notes

<!-- Anything else reviewers should know: breaking changes, performance implications, open questions, etc. -->
This PR adds support for Apple Metal Performance Shaders (MPS) devices when using the PyTorch backend.

Changes:
- Detect PyTorch MPS availability in choose_device()
- Return "mps" when MPS is available
